### PR TITLE
Fix url missing module

### DIFF
--- a/widgets/AuthItemDescriptionColumn.php
+++ b/widgets/AuthItemDescriptionColumn.php
@@ -44,7 +44,7 @@ class AuthItemDescriptionColumn extends AuthItemColumn
 
         echo CHtml::link(
             $data['item']->description,
-            array('/auth/' . $controller->getItemControllerId($data['item']->type) . '/view', 'name' => $data['name']),
+            array($controller->getItemControllerId($data['item']->type) . '/view', 'name' => $data['name']),
             array('class' => $linkCssClass)
         );
     }


### PR DESCRIPTION
Remove the absolute path generation and use the relative path instead.
The preceding slash also prevented yii generate url without considering
the module of the controller.

https://jira.aminocom.com/browse/BPLAT-4219